### PR TITLE
Server can allow remote connections now

### DIFF
--- a/marketeer_server/Makefile
+++ b/marketeer_server/Makefile
@@ -1,0 +1,2 @@
+all:
+	g++ -std=c++17 -o marketeer_server -O2 -lwolfssl -lnng *.cpp

--- a/marketeer_server/marketeer_server.cpp
+++ b/marketeer_server/marketeer_server.cpp
@@ -467,7 +467,7 @@ int main(int argc, char* argv[])
 
     // These substring sizes are determined somewhere in the client code
     if (argc > 1)
-        serverURL = std::move("ipc://" + std::string(argv[1]).substr(0, 127));
+        serverURL = std::move(std::string(argv[1]).substr(0, 133));
     if (argc > 2)
         adminPassword = std::move(std::string(argv[2]).substr(0, 16));
 


### PR DESCRIPTION
Create a server to allow remote clients to connect:

- Server url: `tcp://<localhost ip>:<port>`
- Client url: `tcp://<host external ip>:<port>`

Note: for server you can have the localhost ip as * or leave empty like `tcp://:<port>`. See [nng_tcp(7)](https://nng.nanomsg.org/man/tip/nng_tcp.7.html#_uri_format) for more information.