### PR TITLE
Add Royalflare Archive link and fix UTF-8 strings

### DIFF
--- a/thprac/src/thprac/thprac_launcher_cfg.cpp
+++ b/thprac/src/thprac/thprac_launcher_cfg.cpp
@@ -1482,7 +1482,7 @@ private:
 
         ImGui::Text(XSTR(THPRAC_SETTING_LANGUAGE));
         ImGui::Separator();
-        mCfgLanguage.Gui(XSTR(THPRAC_LANGUAGE), u8"中文\0English\0日本語\0\0");
+        mCfgLanguage.Gui(XSTR(THPRAC_LANGUAGE), "中文\0English\0日本語\0\0");
         if (mOriginalLanguage != mCfgLanguage.Get()) {
             ImGui::Text(th_glossary_str[mCfgLanguage.Get()][THPRAC_LANGUAGE_HINT]);
         }

--- a/thprac/src/thprac/thprac_launcher_links.cpp
+++ b/thprac/src/thprac/thprac_launcher_links.cpp
@@ -59,19 +59,19 @@ private:
     };
     void WriteLinksCfgDefault()
     {
-        const char* debugJsonStr = u8R"123({
-    "Default":{
-        "__is_open__" : true,
-        "Royalflare Archive":"https://maribelhearn.com/royalflare",
-        "Lunarcast":"http://replay.lunarcast.net/",
-        "PND":"https://thscore.pndsng.com/index.php",
-        "Maribel Hearn's Touhou Portal":"https://maribelhearn.com/",
-        "Eientei Forums":"https://eientei.boards.net/",
-        "甜品站 (isndes)":"https://www.isndes.com/",
-        "Touhou Patch":"https://www.thpatch.net/",
-        "THBWiki":"https://thwiki.cc/"
-    }
-})123";
+        const char* debugJsonStr = R"123({
+            "Default":{
+                "__is_open__" : true,
+                "Royalflare Archive":"https://maribelhearn.com/royalflare",
+                "Lunarcast":"http://replay.lunarcast.net/",
+                "PND":"https://thscore.pndsng.com/index.php",
+                "Maribel Hearn's Touhou Portal":"https://maribelhearn.com/",
+                "Eientei Forums":"https://eientei.boards.net/",
+                "甜品站 (isndes)":"https://www.isndes.com/",
+                "Touhou Patch":"https://www.thpatch.net/",
+                "THBWiki":"https://thwiki.cc/"
+            }
+        })123";
         rapidjson::Document linksJson;
         linksJson.Parse(debugJsonStr);
 

--- a/thprac/src/thprac/thprac_launcher_links.cpp
+++ b/thprac/src/thprac/thprac_launcher_links.cpp
@@ -62,6 +62,7 @@ private:
         const char* debugJsonStr = u8R"123({
     "Default":{
         "__is_open__" : true,
+        "Royalflare Archive":"https://maribelhearn.com/royalflare",
         "Lunarcast":"http://replay.lunarcast.net/",
         "PND":"https://thscore.pndsng.com/index.php",
         "Maribel Hearn's Touhou Portal":"https://maribelhearn.com/",


### PR DESCRIPTION
The mojibake in the Links tabs will still show up because it's stored in the config file.
Remove the links object in the config file and thprac will create a new link object with the fixed mojibake