### PR TITLE
Use conformance mode (`/permissive-`)

### DIFF
--- a/thprac/src/thprac/thprac_gui_input.cpp
+++ b/thprac/src/thprac/thprac_gui_input.cpp
@@ -133,7 +133,7 @@ namespace THPrac
 		}
 
 
-		
+
 		/***                   Keyboard Input                     ***/
 
 		static uint8_t __ki_keystatus[0xFF]{};
@@ -147,12 +147,6 @@ namespace THPrac
 			else
 				__ki_keystatus[v_key] = 0;
 			return __ki_keystatus[v_key];
-		}
-		template<class... Args>
-		int KeyboardInputUpdate(int key, Args... rest)
-		{
-			UpdateKey(v_key);
-			UpdateKey(rest...);
 		}
 		void KeyboardInputUpdate()
 		{

--- a/thprac/src/thprac/thprac_th11.cpp
+++ b/thprac/src/thprac/thprac_th11.cpp
@@ -691,17 +691,17 @@ namespace TH11 {
         if (stall)
             ecl << 9999 << 0x00100000 << 0x00ff0000 << 0;
     }
+    void ECLVoid(ECLHelper& ecl, size_t pos)
+    {
+        ecl.SetPos(pos + 4);
+        ecl << (int16_t)0;
+    }
     template <class... Args>
     void ECLVoid(ECLHelper& ecl, size_t pos, Args... rest)
     {
         ecl.SetPos(pos + 4);
         ecl << (int16_t)0;
         ECLVoid(ecl, rest...);
-    }
-    void ECLVoid(ECLHelper& ecl, size_t pos)
-    {
-        ecl.SetPos(pos + 4);
-        ecl << (int16_t)0;
     }
     void ECLSatoriJump(ECLHelper& ecl, int shot_type)
     {
@@ -1697,7 +1697,7 @@ namespace TH11 {
 
         if (result) {
             pCtx->Eip = 0x44aa54;
-        } 
+        }
     }
     EHOOK_DY(th11_game_init, 0x43a0bc)
     {
@@ -1784,14 +1784,14 @@ namespace TH11 {
         if (THBGMTest()) {
             PushHelper32(pCtx, 1);
             pCtx->Eip = 0x42053d;
-        } 
+        }
     }
     EHOOK_DY(th11_bgm_2, 0x420529)
     {
         if (THBGMTest()) {
             PushHelper32(pCtx, 1);
             pCtx->Eip = 0x42052b;
-        } 
+        }
     }
     EHOOK_DY(th11_bgm_3, 0x420542)
     {
@@ -1853,7 +1853,7 @@ namespace TH11 {
         GameGuiInit(IMPL_WIN32_DX9, 0x4c3288, 0x4c3d88, 0x445e00,
             Gui::INGAGME_INPUT_GEN2, 0x4c92b4, 0x4c92b0, 0,
             -1);
-        
+
         // Gui components creation
         THGuiPrac::singleton();
         THGuiRep::singleton();
@@ -1861,7 +1861,7 @@ namespace TH11 {
 
         // Hooks
         THMainHook::singleton().EnableAllHooks();
-        
+
         // Hooks
         THMainHook::singleton().EnableAllHooks();
 

--- a/thprac/src/thprac/thprac_th185.cpp
+++ b/thprac/src/thprac/thprac_th185.cpp
@@ -28,7 +28,7 @@ namespace TH185 {
         std::vector<unsigned int> warp;
         std::vector<unsigned int> force_wave;
         std::vector<unsigned int> additional_cards;
-        
+
         size_t __waves_forced;
     };
     THPracParam thPracParam {};
@@ -79,7 +79,7 @@ namespace TH185 {
                     .writes = {
                         { "main", {
                             { .off = 0x184, .bytes = { 2 } }
-                        } } 
+                        } }
                     }
                 },
                 {
@@ -92,7 +92,7 @@ namespace TH185 {
                     .writes = {
                         { "main", {
                             { .off = 0x184, .bytes = { 3 } }
-                        } } 
+                        } }
                     }
                 },
                 {
@@ -105,7 +105,7 @@ namespace TH185 {
                     .writes = {
                         { "main", {
                             { .off = 0x184, .bytes = { 4 } }
-                        } } 
+                        } }
                     }
                 }
             };
@@ -138,10 +138,10 @@ namespace TH185 {
             break;
         case 1:
             out.section_param = {
-                { 
+                {
                     .label = XSTR(TH185_WAVE_1)
                 },
-                { 
+                {
                     .label = XSTR(TH185_WAVE_2),
                     .jumps = {
                         { "main", {
@@ -154,7 +154,7 @@ namespace TH185 {
                         } }
                     }
                 },
-                { 
+                {
                     .label = XSTR(TH185_WAVE_3),
                     .jumps = {
                         { "main", {
@@ -167,7 +167,7 @@ namespace TH185 {
                         } }
                     }
                 },
-                { 
+                {
                     .label = XSTR(TH_BOSS),
                     .jumps = {
                         { "main", {
@@ -764,12 +764,12 @@ namespace TH185 {
                                 { .off = 0x34, .bytes = { FORCE_BOSS(3, 14) } }
                             } }
                         }
-                    }, 
+                    },
                     {
                         .label = "Nitori Kawashiro",
                         .writes = {
                             { "WorldWaveB00", {
-                                { .off = 0x34, .bytes = {  
+                                { .off = 0x34, .bytes = {
                                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0xFF, 0x02, 0x00, 0x00, 0x00, 0x00, 14, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
                                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0xFF, 0x02, 0x00, 0x00, 0x00, 0x00, 15, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
                                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0xFF, 0x02, 0x00, 0x00, 0x00, 0x00, 16, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
@@ -1053,7 +1053,7 @@ namespace TH185 {
                                 { .off = 0x1b0, .bytes = { 0x18, 0x15, 0x00, 0x00 } }
                             } },
                             { "Boss17Boss1", {
-                                { .off = 0x10, .bytes = { 
+                                { .off = 0x10, .bytes = {
                                 0x00, 0x00, 0x00, 0x00, 0x0F, 0x02, 0x1C, 0x00, 0x00, 0x00, 0xFF, 0x03, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2F, 0x45, 0x80, 0xA0, 0xFF, 0xFF,
                                 BOSS_SPELL_CARD_ASYNC(17, 1)
                             } } } }
@@ -1309,7 +1309,7 @@ namespace TH185 {
                             { "WorldWaveB00", {
                                 { .off = 0x34, .bytes = { {
                                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0xFF, 0x02, 0x00, 0x00, 0x00, 0x00, 0x16, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
-                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0xFF, 0x02, 0x00, 0x00, 0x00, 0x00, 0x17, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0xFF, 0x02, 0x00, 0x00, 0x00, 0x00, 0x17, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
                                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0xFF, 0x02, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
                                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14, 0x00, 0x01, 0x00, 0xFF, 0x01, 0x00, 0x00, 0x00, 0x00, 0x5E, 0xD9, 0xFF, 0xFF,
                                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0xFF, 0x02, 0x00, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -2390,7 +2390,7 @@ namespace TH185 {
                                 { .off = 0x1b0, .bytes = { 0x18, 0x15, 0x00, 0x00 } }
                             } },
                             { "Boss17Boss1", {
-                                { .off = 0x10, .bytes = { 
+                                { .off = 0x10, .bytes = {
                                 0x00, 0x00, 0x00, 0x00, 0x0F, 0x02, 0x1C, 0x00, 0x00, 0x00, 0xFF, 0x03, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2F, 0x45, 0x80, 0xA0, 0xFF, 0xFF,
                                 BOSS_SPELL_CARD_ASYNC(17, 1)
                             } } } }
@@ -2660,7 +2660,7 @@ namespace TH185 {
         {
             SetTitle("Mod Menu");
             SetFade(0.5f, 0.5f);
-            SetCursor(false);
+            SetCursor(NULL);
             SetPos(10.0f, 10.0f);
             SetSize(0.0f, 0.0f);
             SetWndFlag(
@@ -3034,7 +3034,7 @@ namespace TH185 {
             mMode();
             if (*mMode == 1) {
                 StageWarpsRender(warps, mWarp, 0);
-                
+
                 mLife();
                 mFunds();
                 mBulletMoney();

--- a/thprac/src/thprac/thprac_utils.h
+++ b/thprac/src/thprac/thprac_utils.h
@@ -479,32 +479,32 @@ void* VFSOriginal(const char* file_name, int32_t* file_size, int32_t is_file);
 
 #pragma region Memory Helper
 
-template <class... Args>
-inline uint32_t GetMemContent(int addr, int offset, Args... rest)
+inline uint32_t GetMemContent(int addr)
 {
-    return GetMemContent((int)(*((uint32_t*)addr) + (uint32_t)offset), rest...);
+    return *((uint32_t*)addr);
 }
 inline uint32_t GetMemContent(int addr, int offset)
 {
     return *((uint32_t*)(*((uint32_t*)addr) + (uint32_t)offset));
 }
-inline uint32_t GetMemContent(int addr)
+template <class... Args>
+inline uint32_t GetMemContent(int addr, int offset, Args... rest)
 {
-    return *((uint32_t*)addr);
+    return GetMemContent((int)(*((uint32_t*)addr) + (uint32_t)offset), rest...);
 }
 
-template <class... Args>
-inline uint32_t GetMemAddr(int addr, int offset, Args... rest)
+inline uint32_t GetMemAddr(int addr)
 {
-    return GetMemAddr((int)(*((uint32_t*)addr) + (uint32_t)offset), rest...);
+    return (uint32_t)addr;
 }
 inline uint32_t GetMemAddr(int addr, int offset)
 {
     return (*((uint32_t*)addr) + (uint32_t)offset);
 }
-inline uint32_t GetMemAddr(int addr)
+template <class... Args>
+inline uint32_t GetMemAddr(int addr, int offset, Args... rest)
 {
-    return (uint32_t)addr;
+    return GetMemAddr((int)(*((uint32_t*)addr) + (uint32_t)offset), rest...);
 }
 
 #define MDARRAY(arr, idx, size_of_subarray) (arr + idx * size_of_subarray)

--- a/thprac/thprac.vcxproj
+++ b/thprac/thprac.vcxproj
@@ -212,7 +212,7 @@
       <PreprocessorDefinitions>WIN32;HAVE_SSE2;_CRT_SECURE_NO_WARNINGS;_WINDOWS;WINVER=0x0601;_WIN32_WINNT=0x0601;DISTORM_LIGHT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <LanguageStandard Condition="'$(ToolsetType)'=='MSVC'">stdcpp20</LanguageStandard>
       <LanguageStandard Condition="'$(ToolsetType)'=='ClangCL'">stdcpplatest</LanguageStandard>
-      <ConformanceMode>false</ConformanceMode>
+      <ConformanceMode>true</ConformanceMode>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <ControlFlowGuard>false</ControlFlowGuard>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>


### PR DESCRIPTION
`/permissive-` documentation available [here](https://docs.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-170).

Will eventually be needed for #105, but might also be useful in the shorter-term. Also _might_ improve compatibility with non-MSVC toolchains? ([citation needed](https://en.wikipedia.org/wiki/Wikipedia:Citation_needed))

Additional thanks to [zero318](https://github.com/zero318) for helping me fix some compile errors.