### PR TITLE
Fix & improvements to th20 patches

### DIFF
--- a/thprac/src/thprac/thprac_th20.cpp
+++ b/thprac/src/thprac/thprac_th20.cpp
@@ -560,7 +560,7 @@ namespace TH20 {
         HOTKEY_ENDDEF();
 
         HOTKEY_DEFINE(mInfLives, TH_INFLIVES, "F2", VK_F2)
-        PATCH_HK(0xE1288, "660F1F440000")
+        PATCH_HK(0xF849D, "00")
         HOTKEY_ENDDEF();
 
         HOTKEY_DEFINE(mInfBombs, TH_INFBOMBS, "F3", VK_F3)
@@ -568,7 +568,7 @@ namespace TH20 {
         HOTKEY_ENDDEF();
 
         HOTKEY_DEFINE(mInfPower, TH_INFPOWER, "F4", VK_F4)
-        PATCH_HK(0xE16A2, "0F1F00")
+        PATCH_HK(0xE16A2, "0F1F00") //0xE16A8
         HOTKEY_ENDDEF();
 
         HOTKEY_DEFINE(mHyperGLock, TH20_HYP_LOCK, "F5", VK_F5)
@@ -585,7 +585,8 @@ namespace TH20 {
         HOTKEY_ENDDEF();
 
         HOTKEY_DEFINE(mAutoBomb, TH_AUTOBOMB, "F8", VK_F8)
-        PATCH_HK(0xF79B3, "FF")
+        PATCH_HK(0xF79AC, "0F"),
+        PATCH_HK(0xF79B3, "0F")
         HOTKEY_ENDDEF();
     public:
         Gui::GuiHotKey mElBgm { TH_EL_BGM, "F9", VK_F9 };


### PR DESCRIPTION
Now implementing the AutoBomb in a way that only perform it when it was possible in the vanilla game, in another word, avoided a situation that the original code does not allow a DeathBomb to happen (by setting the flag to a 0, regardless the player input) but we forced it to happen (CMP that flag with a FF). I found no issue with original implementation while testing but theoretically it's 100% safe right now.

Fixed the way of patching infLives. The previous way voided the assigning progress to variable that holds Lives within the Life modification function, but the latter accept a signed argument as the offset to modify the Lives value, therefore the previous way will not only stop player from dropping life, may also stop player from gaining life (such as a call from RVA 0xE151C, with a argument 1, will also be voided). A better way is to just modifying the PUSH instruction, at the place that game performs the life-dropping logic, from FF to 00.