### PR TITLE
th20: fixed priority meters taking value of level meter

### DIFF
--- a/thprac/src/thprac/thprac_th20.cpp
+++ b/thprac/src/thprac/thprac_th20.cpp
@@ -153,6 +153,10 @@ namespace TH20 {
             *mLevelB = 0;
             *mLevelY = 0;
             *mLevelG = 0;
+            *mPriorityR = 0;
+            *mPriorityB = 0;
+            *mPriorityY = 0;
+            *mPriorityG = 0;
 
             SetFade(0.8f, 0.1f);
             SetStyle(ImGuiStyleVar_WindowRounding, 0.0f);
@@ -202,13 +206,13 @@ namespace TH20 {
                 thPracParam.stone = *mStone / 10000.0f;
                 thPracParam.stoneMax = stoneMaxStageDefault + *mStoneSummoned * 150;
                 thPracParam.levelR = *mLevelR;
-                thPracParam.priorityR = *mLevelR;
+                thPracParam.priorityR = *mPriorityR;
                 thPracParam.levelB = *mLevelB;
-                thPracParam.priorityB = *mLevelB;
+                thPracParam.priorityB = *mPriorityB;
                 thPracParam.levelG = *mLevelG;
-                thPracParam.priorityG = *mLevelG;
+                thPracParam.priorityG = *mPriorityG;
                 thPracParam.levelY = *mLevelY;
-                thPracParam.priorityY = *mLevelY;
+                thPracParam.priorityY = *mPriorityY;
                 break;
             }
             case 4:


### PR DESCRIPTION
This commit fixes a practice issue with the pyramid priority meters taking their value from the pyramid level meter, fixing the issue of the practice priority meters not working as intended before