### PR TITLE
th16, th17, th18: removed (null) column from appearing in replay user menu

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ If you have been sending a lot of pull requests, congratulations, you might have
 
 According to Section "6.1.2. Allowed Game Modifications" in the [official handbook](https://docs.google.com/document/d/e/2PACX-1vQrmgcwhgKARoUnk5BPE0Oyv4fAgHilZs1pUa1RQJtm0X_z93L8eI0lNt1Y-iZQK3v4_Ab9vx1HzpkN/pub#h.9j7h74u3d3zf) all GitHub Actions builds created from a commit on the `master` branch** are allowed.
 
-What this means in detail is that players are allowed to keep thprac injected into their game while attempting a credit, as long as all features from the backspace menu are disabled. This is because thprac gets out of the way and does not allow for any of it's features to activate during a full game run.
+What this means in detail is that players are allowed to keep thprac injected into their game while attempting a credit, as long as all features from the backspace menu are disabled. This is because thprac gets out of the way and does not allow for any of its features to activate during a full game run.
 
 To clarify: players are allowed to show themselves use other mods during TWC, but they must restart restart their games before attempting credits, otherwise these credits are not counted. If a player shows themselves using thprac on the other hand, they do **NOT** need to restart the game for credits to be considered valid.
 

--- a/thprac/src/thprac/thprac_games_def.json
+++ b/thprac/src/thprac/thprac_games_def.json
@@ -8,7 +8,7 @@
 
       "THPRAC_PR_INFO_ATTACHED": [
         "已应用thprac。\n如无事发生，请在游戏中回到主菜单一次。",
-        "Applied thprac.\nIf nothing happend, return to main menu in game once.",
+        "Applied thprac.\nIf nothing happened, return to main menu in game once.",
         "thpracが適用されました。\n何も起こらない場合は、一度、ゲームのメインメニューに戻ってください。"
       ],
       "THPRAC_PR_ASK_ATTACH": [

--- a/thprac/src/thprac/thprac_locale_def.cpp
+++ b/thprac/src/thprac/thprac_locale_def.cpp
@@ -1837,7 +1837,7 @@ const char* th_glossary_str[3][1048]
         "Fatal error occurred while initializing thprac.",
         "No valid game was found.",
         "Failed to run game.",
-        "Applied thprac.\nIf nothing happend, return to main menu in game once.",
+        "Applied thprac.\nIf nothing happened, return to main menu in game once.",
         "Purge",
         "Reflective launch",
         "Enable if the game behaves abnormally when launched by thprac but not when launched directly.\nThis will nullify any functionality that requires a direct game launch from thprac.",

--- a/thprac/src/thprac/thprac_th16.cpp
+++ b/thprac/src/thprac/thprac_th16.cpp
@@ -2403,6 +2403,12 @@ namespace TH16 {
         // Hooks
         EnableAllHooks(THMainHook);
 
+        // Replay user menu (null) fix
+        DWORD oldProtect;
+        VirtualProtect((void*)0x493708, 4, PAGE_EXECUTE_READWRITE, &oldProtect);
+        *(const char**)(0x493708) = "%s  %s %.2d/%.2d/%.2d %.2d:%.2d %s %s %s %s %2.1f%%";
+        VirtualProtect((void*)0x493708, 4, oldProtect, &oldProtect); 
+
         // Reset thPracParam
         thPracParam.Reset();
     }

--- a/thprac/src/thprac/thprac_th17.cpp
+++ b/thprac/src/thprac/thprac_th17.cpp
@@ -2014,6 +2014,12 @@ namespace TH17 {
         EnableAllHooks(THMainHook);
         th17_force_goast_angle.Setup();
 
+        // Replay user menu (null) fix
+        DWORD oldProtect;
+        VirtualProtect((void*)0x4a2cb8, 4, PAGE_EXECUTE_READWRITE, &oldProtect);
+        *(const char**)(0x4a2cb8) = "%s  %s %.2d/%.2d/%.2d %.2d:%.2d %s %s %s %2.1f%%";
+        VirtualProtect((void*)0x4a2cb8, 4, oldProtect, &oldProtect); 
+
         // Reset thPracParam
         thPracParam.Reset();
     }

--- a/thprac/src/thprac/thprac_th18.cpp
+++ b/thprac/src/thprac/thprac_th18.cpp
@@ -3071,6 +3071,12 @@ namespace TH18 {
         // Hooks
         EnableAllHooks(THMainHook);
 
+        // Replay user menu (null) fix
+        DWORD oldProtect;
+        VirtualProtect((void*)0x4b7ad8, 4, PAGE_EXECUTE_READWRITE, &oldProtect);
+        *(const char**)(0x4b7ad8) = "%s  %s %.2d/%.2d/%.2d %.2d:%.2d %s %s %s %2.1f%%";
+        VirtualProtect((void*)0x4b7ad8, 4, oldProtect, &oldProtect); 
+
         // Reset thPracParam
         thPracParam.Reset();
     }


### PR DESCRIPTION
This fixed the (null) column from appearing in th16, th17, and th18 (th20 is already patched, replays do not exist for th185 and th19, and this bug was not there before th16)

Before patch:
<img width="1278" height="747" alt="image" src="https://github.com/user-attachments/assets/a0c3f1ee-25c0-4174-a345-a5b9a73d2da4" />

After patch:
<img width="1279" height="744" alt="image" src="https://github.com/user-attachments/assets/4a1f1f96-35c3-4690-8efd-81863680d0ee" />

