### PR TITLE
fix th128 A2 Nonspell bug

### DIFF
--- a/thprac/src/thprac/thprac_th128.cpp
+++ b/thprac/src/thprac/thprac_th128.cpp
@@ -1421,10 +1421,10 @@ namespace TH128 {
             break;
         case THPrac::TH128::TH128_A23_BOSS5:
             ECL3Boss(ecl, 0x7ce4, false);
+            ecl.SetFile(2);
             ecl << pair{0x62c8, (int8_t)0x33};
             ecl << pair{0x64a0, (int8_t)0x33};
             ecl << pair{0x6678, (int8_t)0x33};
-            ecl.SetFile(2);
             break;
         case THPrac::TH128::TH128_A23_BOSS6:
             ECL3Boss(ecl, 0x7ce4, false);
@@ -1433,10 +1433,10 @@ namespace TH128 {
             break;
         case THPrac::TH128::TH128_A23_BOSS7:
             ECL3Boss(ecl, 0x7ce4, false);
+            ecl.SetFile(2);
             ecl << pair{0x62c8, (int8_t)0x34};
             ecl << pair{0x64a0, (int8_t)0x34};
             ecl << pair{0x6678, (int8_t)0x34};
-            ecl.SetFile(2);
             break;
         case THPrac::TH128::TH128_A23_BOSS8:
             ECL3Boss(ecl, 0x7ce4, false);


### PR DESCRIPTION
At present, you select A2 last boss non spell 3 or 4, you will play A2 last boss non spell 1