### PR TITLE
Clarify a log message in "main.cpp"

### DIFF
--- a/thprac/src/thprac/main.cpp
+++ b/thprac/src/thprac/main.cpp
@@ -141,7 +141,7 @@ inline CmdlineRet doCmdLineStuff(PWSTR cmdLine) {
         if (DetectGame(argv[i], &sig)) {
             exeFn = argv[i];
         } else {
-            fwprintf(stderr, L"Warning: invalid filename %s\n", argv[i]);
+            fwprintf(stderr, L"Warning: %s is not a valid Touhou game executable. If you're having issues, consider using command line arguments to pass the filename to thprac. More at https://github.com/touhouworldcup/thprac\n", argv[i]);
         }
         i++;
     }


### PR DESCRIPTION
I myself spent a lot of time figuring out why my thprac wouldn't work and this message was really misleading. In my case, I ran it via wine, and it basically just closed right away with a message "Invalid filename .../.../thprac.exe". Only after skimming through the code I figured out that is supposed to be about the games themselves. I believe a log message like this would be more helpful to people who care to read through logs to begin with.

As for performance on wine, I only got it working via CLI parameters as I described, although I'm not sure if it's reproducible and I don't insist on recommending CLI in particular. My main gripe is the vague wording.