### PR TITLE
Fix Japanese text in thprac_games_def.json

### DIFF
--- a/thprac/src/thprac/thprac_games_def.json
+++ b/thprac/src/thprac/thprac_games_def.json
@@ -3138,7 +3138,7 @@
         "bgm": 1,
         "spell": 1,
         "appearance": [ 9, 2, 14 ],
-        "!X": [ "不灭「不死鸟之尾」", "Inextinguishable \"Phoenix's Tail\"", "復燃「恋の埋火」" ]
+        "!X": [ "不灭「不死鸟之尾」", "Inextinguishable \"Phoenix's Tail\"", "不滅「フェニックスの尾」" ]
       },
       "TH08_ST7_END_NS8": {
         "bgm": 1,


### PR DESCRIPTION
Fix Japanese text in `thprac_games_def.json`. (`TH08_ST7_END_S7`)

```diff
-"!X": [ "不灭「不死鸟之尾」", "Inextinguishable \"Phoenix's Tail\"", "復燃「恋の埋火」" ]
+"!X": [ "不灭「不死鸟之尾」", "Inextinguishable \"Phoenix's Tail\"", "不滅「フェニックスの尾」" ]
```