### PR TITLE
fix(th06): pass the real AnmManager to ECLNameFix

### DIFF
--- a/thprac/src/thprac/thprac_th06.cpp
+++ b/thprac/src/thprac/thprac_th06.cpp
@@ -20,7 +20,8 @@ namespace TH06 {
     static Chain* const CHAIN = (Chain* const)0x69d918;
     static GameWindow* const GAME_WINDOW = (GameWindow* const)0x6c6bd4;
     static Supervisor* const SUPERVISOR = (Supervisor* const)0x6c6d18;
-    static AnmManager* const ANM_MANAGER = (AnmManager* const)0x6d4588;
+    // 0x6d4588 holds a pointer to the AnmManager, not the object itself.
+    static AnmManager** const ANM_MANAGER = (AnmManager** const)0x6d4588;
     static MainMenu* const MAIN_MENU = (MainMenu* const)0x6d46c0;
 
     enum ADDRS {
@@ -970,7 +971,7 @@ namespace TH06 {
     }
     void ECLNameFix()
     {
-        void* thisPtr = (void*)(ANM_MANAGER);
+        void* thisPtr = (void*)(*ANM_MANAGER);
         if (thPracParam.stage == 5) {
             asm_call<0x431dc0, Thiscall>(thisPtr, 11, "data/eff06.anm", 691);
         } else if (thPracParam.stage == 6) {


### PR DESCRIPTION
## Problem

Entering any Stage 6 boss section or Extra boss section in TH06 practice crashes the game immediately with `0xc0000005`.

## Cause

`ECLNameFix` loads the boss name sprites by calling `AnmManager::LoadFile` (`0x431dc0`) with `0x6d4588` as `this`:

```cpp
static AnmManager* const ANM_MANAGER = (AnmManager* const)0x6d4588;
...
void* thisPtr = (void*)(ANM_MANAGER);
asm_call<0x431dc0, Thiscall>(thisPtr, 11, "data/eff07.anm", 691);
```

In TH06 1.02h that address is not the `AnmManager` itself, it is the global pointer variable holding it. The game always loads the value first:

```
004013AF: mov  ecx, dword ptr ds:[006D4588h]
004013B5: call 00431DC0
```

With the wrong `this`, the callee reads `this + 0x20934 + slot * 4` = `0x6f4ee8`, which is past the end of the image (`0x400000`-`0x6e8fff`), so it always faults.

`ECLNameFix` only does work for `stage == 5` (Stage 6) and `stage == 6` (Extra), which is exactly the set of sections that crash.

## Evidence

From a crash dump of the faulting process:

| | |
|---|---|
| Exception | `0xc0000005` (read) at `0x432040` |
| `ecx` (`this`) | `0x006d4588` — the address of the pointer variable |
| `eax` (slot) | `0x0b` = `data/eff07.anm` |
| Faulting address | `0x006f4ee8` = `0x6d4588 + 11 * 4 + 0x20934` |
| `*(0x6d4588)` | `0x04430048` — the real object, on the heap |
| Frame #1 | `THPrac::TH06::ECLNameFix` |

## Fix

Treat `0x6d4588` as the pointer it is, matching how TH07 already declares the same manager (`AnmManager** ANM_MANAGER`).

The rebuilt code now matches the game's own calling sequence:

```
004915B6: mov  esi, dword ptr ds:[6D4588h]
004915EF: mov  ecx, esi
004915F1: call edi                          ; 0x431DC0
```

## Testing

- Release x86 build: 0 errors, no new warnings
- Verified in game: Stage 6 boss sections and Extra boss sections (including QED "Ripples of 495 Years") now start normally instead of crashing
- Stage 5 and Extra midboss sections unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)